### PR TITLE
Fix horizontal scroll

### DIFF
--- a/styles/main.scss
+++ b/styles/main.scss
@@ -10,7 +10,7 @@ body {
   padding: 0;
 }
 header {
-  width: 100%;
+  width: calc(100% - 16px);
   background-color: #388E3C;
   color: #fff;
   margin: 0;


### PR DESCRIPTION
The <header> element had a width of 100% plus padding, which resulted in horizontal scrolling.